### PR TITLE
IS-2621: Add stansdato to stans vurdering

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/model/VurderingResponseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/model/VurderingResponseDTO.kt
@@ -13,6 +13,7 @@ data class VurderingResponseDTO private constructor(
     val vurderingType: VurderingType,
     val veilederident: String,
     val begrunnelse: String,
+    val stansdato: LocalDate?,
     val document: List<DocumentComponent>,
     val varsel: VarselDTO?,
 ) {
@@ -24,6 +25,7 @@ data class VurderingResponseDTO private constructor(
             vurderingType = vurdering.vurderingType,
             veilederident = vurdering.veilederident.value,
             begrunnelse = vurdering.begrunnelse,
+            stansdato = if (vurdering is Vurdering.Stans) vurdering.stansdato else null,
             document = vurdering.document,
             varsel = if (vurdering is Vurdering.Forhandsvarsel) VarselDTO.fromVarsel(vurdering.varsel) else null,
         )

--- a/src/main/kotlin/no/nav/syfo/application/VurderingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/VurderingService.kt
@@ -40,6 +40,7 @@ class VurderingService(
                     personident = Personident(newVurdering.personident),
                     veilederident = veilederident,
                     begrunnelse = newVurdering.begrunnelse,
+                    stansdato = newVurdering.stansdato,
                     document = newVurdering.document,
                 )
             is NewVurderingRequestDTO.IkkeAktuell ->

--- a/src/main/kotlin/no/nav/syfo/application/model/NewVurderingRequestDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/application/model/NewVurderingRequestDTO.kt
@@ -31,6 +31,7 @@ sealed class NewVurderingRequestDTO {
         override val personident: String,
         override val begrunnelse: String,
         override val document: List<DocumentComponent>,
+        val stansdato: LocalDate,
     ) : NewVurderingRequestDTO()
 
     @JsonTypeName("IKKE_AKTUELL")

--- a/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
@@ -45,6 +45,7 @@ sealed class Vurdering(val vurderingType: VurderingType) : IVurdering {
         override val begrunnelse: String,
         override val document: List<DocumentComponent>,
         override val journalpostId: JournalpostId?,
+        val stansdato: LocalDate,
     ) : Vurdering(VurderingType.STANS)
 
     data class IkkeAktuell(
@@ -132,6 +133,7 @@ sealed class Vurdering(val vurderingType: VurderingType) : IVurdering {
             personident: Personident,
             veilederident: Veilederident,
             begrunnelse: String,
+            stansdato: LocalDate,
             document: List<DocumentComponent>,
         ) = Stans(
             uuid = UUID.randomUUID(),
@@ -139,6 +141,7 @@ sealed class Vurdering(val vurderingType: VurderingType) : IVurdering {
             veilederident = veilederident,
             createdAt = OffsetDateTime.now(),
             begrunnelse = begrunnelse,
+            stansdato = stansdato,
             document = document,
             journalpostId = null,
         )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVurdering.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Veilederident
 import no.nav.syfo.domain.Vurdering
 import no.nav.syfo.domain.VurderingType
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -18,6 +19,7 @@ data class PVurdering(
     val veilederident: Veilederident,
     val type: VurderingType,
     val begrunnelse: String,
+    val stansdato: LocalDate?,
     val document: List<DocumentComponent>,
     val journalpostId: JournalpostId?,
     val publishedAt: OffsetDateTime?,
@@ -50,6 +52,7 @@ data class PVurdering(
                 veilederident = veilederident,
                 createdAt = createdAt,
                 begrunnelse = begrunnelse,
+                stansdato = stansdato!!,
                 document = document,
                 journalpostId = journalpostId,
             )

--- a/src/test/kotlin/no/nav/syfo/api/endpoints/ManglendeMedvirkningEndpointsSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/endpoints/ManglendeMedvirkningEndpointsSpek.kt
@@ -101,12 +101,12 @@ object ManglendeMedvirkningEndpointsSpek : Spek({
                     val stansVurdering = NewVurderingRequestDTO.Stans(
                         personident = ARBEIDSTAKER_PERSONIDENT.value,
                         begrunnelse = "Fin begrunnelse",
+                        stansdato = LocalDate.now().plusDays(5),
                         document = generateDocumentComponent(
                             fritekst = begrunnelse,
                             header = "Stans"
                         ),
                     )
-                    val json = objectMapper.writeValueAsString(stansVurdering)
                     with(
                         handleRequest(HttpMethod.Post, "$urlVurderinger/vurderinger") {
                             addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
@@ -119,6 +119,7 @@ object ManglendeMedvirkningEndpointsSpek : Spek({
                         responseDTO.personident shouldBeEqualTo stansVurdering.personident
                         responseDTO.vurderingType shouldBeEqualTo VurderingType.STANS
                         responseDTO.begrunnelse shouldBeEqualTo stansVurdering.begrunnelse
+                        responseDTO.stansdato shouldBeEqualTo stansVurdering.stansdato
                         responseDTO.veilederident shouldBeEqualTo VEILEDER_IDENT.value
                         responseDTO.document shouldBeEqualTo stansVurdering.document
                         responseDTO.varsel?.svarfrist shouldBeEqualTo null

--- a/src/test/kotlin/no/nav/syfo/generator/VurderingGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/VurderingGenerator.kt
@@ -51,6 +51,7 @@ fun generateVurdering(
         personident = personident,
         veilederident = UserConstants.VEILEDER_IDENT,
         begrunnelse = begrunnelse,
+        stansdato = LocalDate.now().plusDays(5),
         document = document,
         journalpostId = null,
     )

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/VurderingRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/VurderingRepositorySpek.kt
@@ -44,6 +44,32 @@ class VurderingRepositorySpek : Spek({
                     savedVurdering.journalpostId shouldBeEqualTo vurdering.journalpostId
                 }
 
+                it("saves a vurdering of type STANS") {
+                    val vurdering = Vurdering.Stans(
+                        uuid = UUID.randomUUID(),
+                        personident = ARBEIDSTAKER_PERSONIDENT,
+                        veilederident = VEILEDER_IDENT,
+                        createdAt = nowUTC(),
+                        begrunnelse = "Begrunnelse",
+                        stansdato = nowUTC().toLocalDate(),
+                        document = emptyList(),
+                        journalpostId = null,
+                    )
+                    val savedVurdering = vurderingRepository.saveManglendeMedvirkningVurdering(vurdering, pdf)
+                    when (savedVurdering) {
+                        is Vurdering.Stans -> {
+                            savedVurdering.personident shouldBeEqualTo vurdering.personident
+                            savedVurdering.veilederident shouldBeEqualTo vurdering.veilederident
+                            savedVurdering.begrunnelse shouldBeEqualTo vurdering.begrunnelse
+                            savedVurdering.stansdato shouldBeEqualTo vurdering.stansdato
+                            savedVurdering.document shouldBeEqualTo vurdering.document
+                            savedVurdering.journalpostId shouldBeEqualTo vurdering.journalpostId
+                        }
+                        else ->
+                            throw IllegalStateException("Expected Vurdering.Stans, got $savedVurdering")
+                    }
+                }
+
                 it("saves a vurdering with a varsel") {
                     val now = nowUTC()
                     val vurdering = Vurdering.Forhandsvarsel(


### PR DESCRIPTION
Legger til muligheten for å sende inn `stansdato` når man gjør en vurdering av typen stans.

**Spørsmål**: Det er vel ingen som enda er kommet til en stans vurdering rundt manglende medvirkning? Så her kan vi gå rett på at `stansdato` skal være obligatorisk for en stans vurdering? 😊

Se [tilhørende PR i syfomodiaperson](https://github.com/navikt/syfomodiaperson/actions/runs/11145225445/job/30974317256?pr=1478)

- [x] PR i `syfomodiaperson` må merges før denne