### PR TITLE
IS-2621: Set value for stansdato on all vurderinger of type STANS

### DIFF
--- a/src/main/resources/db/migration/V1_5__set_value_on_stansdato_for_all_vurderinger_of_type_stans.sql
+++ b/src/main/resources/db/migration/V1_5__set_value_on_stansdato_for_all_vurderinger_of_type_stans.sql
@@ -1,0 +1,3 @@
+UPDATE VURDERING
+SET stansdato = created_at
+WHERE type = 'STANS';


### PR DESCRIPTION
Ettersom det ikke er gjort noen stans vurderinger i prod vil dette bare påvirke dev data. Alle vurderinger av typen stans skal ha en verdi for `stansdato`. Setter derfor `stansdato` til `createdAt` for alle vurderinger som allerede er gjort i dev.

Tilhørende PR'er:
- [ismanglendemedvirkning](https://github.com/navikt/ismanglendemedvirkning/pull/35)
- [syfomodiaperson](https://github.com/navikt/syfomodiaperson/pull/1478)