### PR TITLE
IS-2643: Turn off journalforing retry in dev

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -73,6 +73,8 @@ spec:
   env:
     - name: KTOR_ENV
       value: "production"
+    - name: JOURNALFORING_CRONJOB_ENABLED
+      value: "false"
     - name: ISTILGANGSKONTROLL_CLIENT_ID
       value: "dev-gcp.teamsykefravr.istilgangskontroll"
     - name: ISTILGANGSKONTROLL_URL

--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -73,7 +73,7 @@ spec:
   env:
     - name: KTOR_ENV
       value: "production"
-    - name: JOURNALFORING_CRONJOB_ENABLED
+    - name: JOURNALFORING_RETRY_ENABLED
       value: "false"
     - name: ISTILGANGSKONTROLL_CLIENT_ID
       value: "dev-gcp.teamsykefravr.istilgangskontroll"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -73,6 +73,8 @@ spec:
   env:
     - name: KTOR_ENV
       value: "production"
+    - name: JOURNALFORING_CRONJOB_ENABLED
+      value: "true"
     - name: ISTILGANGSKONTROLL_CLIENT_ID
       value: "prod-gcp.teamsykefravr.istilgangskontroll"
     - name: ISTILGANGSKONTROLL_URL

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -73,7 +73,7 @@ spec:
   env:
     - name: KTOR_ENV
       value: "production"
-    - name: JOURNALFORING_CRONJOB_ENABLED
+    - name: JOURNALFORING_RETRY_ENABLED
       value: "true"
     - name: ISTILGANGSKONTROLL_CLIENT_ID
       value: "prod-gcp.teamsykefravr.istilgangskontroll"

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -70,7 +70,7 @@ fun main() {
     val journalforingService = JournalforingService(
         dokarkivClient = dokarkivClient,
         pdlClient = pdlClient,
-        isJournalforingRetryEnabeled = environment.isJournalforingRetryEnabled,
+        isJournalforingRetryEnabled = environment.isJournalforingRetryEnabled,
     )
 
     val vurderingPdfService = VurderingPdfService(

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -70,7 +70,7 @@ fun main() {
     val journalforingService = JournalforingService(
         dokarkivClient = dokarkivClient,
         pdlClient = pdlClient,
-        journalforingRetryEnabeled = environment.journalforingRetryEnabled,
+        isJournalforingRetryEnabeled = environment.isJournalforingRetryEnabled,
     )
 
     val vurderingPdfService = VurderingPdfService(

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -70,6 +70,7 @@ fun main() {
     val journalforingService = JournalforingService(
         dokarkivClient = dokarkivClient,
         pdlClient = pdlClient,
+        journalforingRetryEnabeled = environment.journalforingRetryEnabled,
     )
 
     val vurderingPdfService = VurderingPdfService(

--- a/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
@@ -51,7 +51,7 @@ data class Environment(
         aivenSecurityProtocol = "SSL",
         aivenTruststoreLocation = getEnvVar("KAFKA_TRUSTSTORE_PATH"),
     ),
-    val journalforingRetryEnabled: Boolean = getEnvVar("JOURNALFORING_RETRY_ENABLED").toBoolean(),
+    val isJournalforingRetryEnabled: Boolean = getEnvVar("JOURNALFORING_RETRY_ENABLED").toBoolean(),
 )
 
 fun getEnvVar(

--- a/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
@@ -51,6 +51,7 @@ data class Environment(
         aivenSecurityProtocol = "SSL",
         aivenTruststoreLocation = getEnvVar("KAFKA_TRUSTSTORE_PATH"),
     ),
+    val journalforingCronjobEnabled: Boolean = getEnvVar("JOURNALFORING_CRONJOB_ENABLED").toBoolean(),
 )
 
 fun getEnvVar(

--- a/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
@@ -51,7 +51,7 @@ data class Environment(
         aivenSecurityProtocol = "SSL",
         aivenTruststoreLocation = getEnvVar("KAFKA_TRUSTSTORE_PATH"),
     ),
-    val journalforingCronjobEnabled: Boolean = getEnvVar("JOURNALFORING_CRONJOB_ENABLED").toBoolean(),
+    val journalforingRetryEnabled: Boolean = getEnvVar("JOURNALFORING_RETRY_ENABLED").toBoolean(),
 )
 
 fun getEnvVar(

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -25,10 +25,10 @@ fun launchCronjobs(
     val publishForhandsvarselCronjob = PublishForhandsvarselCronjob(varselService = varselService)
     cronjobs.add(publishForhandsvarselCronjob)
 
-    if (environment.journalforingCronjobEnabled) {
-        val journalforVurderingerCronjob = JournalforVurderingerCronjob(vurderingService)
-        cronjobs.add(journalforVurderingerCronjob)
-    }
+    val journalforVurderingerCronjob = JournalforVurderingerCronjob(
+        vurderingService = vurderingService,
+    )
+    cronjobs.add(journalforVurderingerCronjob)
 
     cronjobs.forEach {
         launchBackgroundTask(

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -25,8 +25,10 @@ fun launchCronjobs(
     val publishForhandsvarselCronjob = PublishForhandsvarselCronjob(varselService = varselService)
     cronjobs.add(publishForhandsvarselCronjob)
 
-    val journalforVurderingerCronjob = JournalforVurderingerCronjob(vurderingService)
-    cronjobs.add(journalforVurderingerCronjob)
+    if (environment.journalforingCronjobEnabled) {
+        val journalforVurderingerCronjob = JournalforVurderingerCronjob(vurderingService)
+        cronjobs.add(journalforVurderingerCronjob)
+    }
 
     cronjobs.forEach {
         launchBackgroundTask(

--- a/src/main/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingService.kt
@@ -7,12 +7,10 @@ import no.nav.syfo.infrastructure.clients.dokarkiv.dto.*
 import no.nav.syfo.infrastructure.clients.pdl.PdlClient
 import org.slf4j.LoggerFactory
 
-const val DEFAULT_FAILED_JP_ID = 0
-
 class JournalforingService(
     private val dokarkivClient: DokarkivClient,
     private val pdlClient: PdlClient,
-    private val journalforingRetryEnabeled: Boolean,
+    private val isJournalforingRetryEnabeled: Boolean,
 ) : IJournalforingService {
     override suspend fun journalfor(
         personident: Personident,
@@ -30,7 +28,7 @@ class JournalforingService(
         return try {
             dokarkivClient.journalfor(journalpostRequest).journalpostId
         } catch (exc: Exception) {
-            if (journalforingRetryEnabeled) {
+            if (isJournalforingRetryEnabeled) {
                 throw exc
             } else {
                 log.error("Journalføring failed, skipping retry (should only happen in dev-gcp)", exc)
@@ -91,6 +89,7 @@ class JournalforingService(
     }
 
     companion object {
+        const val DEFAULT_FAILED_JP_ID = 0
         private val log = LoggerFactory.getLogger(JournalforingService::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingService.kt
@@ -33,7 +33,10 @@ class JournalforingService(
             if (journalforingRetryEnabeled) {
                 throw exc
             } else {
-                log.warn("Journalforing failed, skipping retry: ", exc)
+                log.error("Journalføring failed, skipping retry (should only happen in dev-gcp)", exc)
+                // Defaulting'en til DEFAULT_FAILED_JP_ID skal bare forekomme i dev-gcp:
+                // Har dette fordi vi ellers spammer ned dokarkiv med forsøk på å journalføre
+                // på personer som mangler aktør-id.
                 DEFAULT_FAILED_JP_ID
             }
         }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingService.kt
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory
 class JournalforingService(
     private val dokarkivClient: DokarkivClient,
     private val pdlClient: PdlClient,
-    private val isJournalforingRetryEnabeled: Boolean,
+    private val isJournalforingRetryEnabled: Boolean,
 ) : IJournalforingService {
     override suspend fun journalfor(
         personident: Personident,
@@ -28,7 +28,7 @@ class JournalforingService(
         return try {
             dokarkivClient.journalfor(journalpostRequest).journalpostId
         } catch (exc: Exception) {
-            if (isJournalforingRetryEnabeled) {
+            if (isJournalforingRetryEnabled) {
                 throw exc
             } else {
                 log.error("Journalføring failed, skipping retry (should only happen in dev-gcp)", exc)

--- a/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
@@ -47,6 +47,7 @@ fun testEnvironment() = Environment(
         ),
     ),
     electorPath = "electorPath",
+    journalforingCronjobEnabled = true,
 )
 
 fun testAppState() = ApplicationState(

--- a/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
@@ -47,7 +47,7 @@ fun testEnvironment() = Environment(
         ),
     ),
     electorPath = "electorPath",
-    journalforingCronjobEnabled = true,
+    journalforingRetryEnabled = true,
 )
 
 fun testAppState() = ApplicationState(

--- a/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
@@ -47,7 +47,7 @@ fun testEnvironment() = Environment(
         ),
     ),
     electorPath = "electorPath",
-    journalforingRetryEnabled = true,
+    isJournalforingRetryEnabled = true,
 )
 
 fun testAppState() = ApplicationState(

--- a/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
@@ -29,7 +29,7 @@ fun Application.testApiModule(
     val journalforingService = JournalforingService(
         dokarkivClient = externalMockEnvironment.dokarkivClient,
         pdlClient = externalMockEnvironment.pdlClient,
-        journalforingRetryEnabeled = externalMockEnvironment.environment.journalforingRetryEnabled,
+        isJournalforingRetryEnabeled = externalMockEnvironment.environment.isJournalforingRetryEnabled,
     )
     val vurderingService =
         VurderingService(

--- a/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
@@ -29,7 +29,7 @@ fun Application.testApiModule(
     val journalforingService = JournalforingService(
         dokarkivClient = externalMockEnvironment.dokarkivClient,
         pdlClient = externalMockEnvironment.pdlClient,
-        isJournalforingRetryEnabeled = externalMockEnvironment.environment.isJournalforingRetryEnabled,
+        isJournalforingRetryEnabled = externalMockEnvironment.environment.isJournalforingRetryEnabled,
     )
     val vurderingService =
         VurderingService(

--- a/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
@@ -29,6 +29,7 @@ fun Application.testApiModule(
     val journalforingService = JournalforingService(
         dokarkivClient = externalMockEnvironment.dokarkivClient,
         pdlClient = externalMockEnvironment.pdlClient,
+        journalforingRetryEnabeled = externalMockEnvironment.environment.journalforingRetryEnabled,
     )
     val vurderingService =
         VurderingService(

--- a/src/test/kotlin/no/nav/syfo/application/VurderingServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/VurderingServiceSpek.kt
@@ -46,7 +46,7 @@ class VurderingServiceSpek : Spek({
         val journalforingService = JournalforingService(
             dokarkivClient = externalMockEnvironment.dokarkivClient,
             pdlClient = externalMockEnvironment.pdlClient,
-            isJournalforingRetryEnabeled = externalMockEnvironment.environment.isJournalforingRetryEnabled,
+            isJournalforingRetryEnabled = externalMockEnvironment.environment.isJournalforingRetryEnabled,
         )
 
         val mockVurderingProducer = mockk<KafkaProducer<String, VurderingRecord>>(relaxed = true)

--- a/src/test/kotlin/no/nav/syfo/application/VurderingServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/VurderingServiceSpek.kt
@@ -46,7 +46,7 @@ class VurderingServiceSpek : Spek({
         val journalforingService = JournalforingService(
             dokarkivClient = externalMockEnvironment.dokarkivClient,
             pdlClient = externalMockEnvironment.pdlClient,
-            journalforingRetryEnabeled = externalMockEnvironment.environment.journalforingRetryEnabled,
+            isJournalforingRetryEnabeled = externalMockEnvironment.environment.isJournalforingRetryEnabled,
         )
 
         val mockVurderingProducer = mockk<KafkaProducer<String, VurderingRecord>>(relaxed = true)

--- a/src/test/kotlin/no/nav/syfo/application/VurderingServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/VurderingServiceSpek.kt
@@ -46,6 +46,7 @@ class VurderingServiceSpek : Spek({
         val journalforingService = JournalforingService(
             dokarkivClient = externalMockEnvironment.dokarkivClient,
             pdlClient = externalMockEnvironment.pdlClient,
+            journalforingRetryEnabeled = externalMockEnvironment.environment.journalforingRetryEnabled,
         )
 
         val mockVurderingProducer = mockk<KafkaProducer<String, VurderingRecord>>(relaxed = true)

--- a/src/test/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingServiceSpek.kt
@@ -30,6 +30,7 @@ object JournalforingServiceSpek : Spek({
         val journalforingService = JournalforingService(
             dokarkivClient = dokarkivMock,
             pdlClient = externalMockEnvironment.pdlClient,
+            journalforingRetryEnabeled = externalMockEnvironment.environment.journalforingRetryEnabled,
         )
 
         beforeEachTest {

--- a/src/test/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingServiceSpek.kt
@@ -30,7 +30,7 @@ object JournalforingServiceSpek : Spek({
         val journalforingService = JournalforingService(
             dokarkivClient = dokarkivMock,
             pdlClient = externalMockEnvironment.pdlClient,
-            isJournalforingRetryEnabeled = externalMockEnvironment.environment.isJournalforingRetryEnabled,
+            isJournalforingRetryEnabled = externalMockEnvironment.environment.isJournalforingRetryEnabled,
         )
 
         beforeEachTest {

--- a/src/test/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingServiceSpek.kt
@@ -30,7 +30,7 @@ object JournalforingServiceSpek : Spek({
         val journalforingService = JournalforingService(
             dokarkivClient = dokarkivMock,
             pdlClient = externalMockEnvironment.pdlClient,
-            journalforingRetryEnabeled = externalMockEnvironment.environment.journalforingRetryEnabled,
+            isJournalforingRetryEnabeled = externalMockEnvironment.environment.isJournalforingRetryEnabled,
         )
 
         beforeEachTest {


### PR DESCRIPTION
Nytt forsøk: Cronjob'en kjører og forsøker å journalføre. Hvis det feiler setter den en defaultverdi hvis JOURNALFORING_RETRY_ENABLED er skrudd av (som det er i dev).