### PR TITLE
IS-3111: Allow ispengestopp read access to topic

### DIFF
--- a/.nais/kafka/manglende-medvirkning-vurdering.yaml
+++ b/.nais/kafka/manglende-medvirkning-vurdering.yaml
@@ -25,6 +25,9 @@ spec:
     - team: teamsykefravr
       application: syfooversiktsrv
       access: read
+    - team: teamsykefravr
+      application: ispengestopp
+      access: read
     - team: disykefravar
       application: dvh-sykefravar-airflow-kafka
       access: read


### PR DESCRIPTION
Sånn at `ispengestopp` kan konsumere vurderinger og gjøre stoppknappetrykk automatisk ved innstilling om stans.