### PR TITLE
IS-3180: Create one-time job to generate new forhandsvarsler for non-notified varsler

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -87,3 +87,5 @@ spec:
       value: "dev-fss.teamdokumenthandtering.dokarkiv-q1"
     - name: DOKARKIV_URL
       value: "https://dokarkiv.dev-fss-pub.nais.io"
+    - name: REPUBLISH_FORHANDSVARSEL_WITH_ADDITIONAL_INFO_CRONJOB_ENABLED
+      value: "true"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -88,4 +88,4 @@ spec:
     - name: DOKARKIV_URL
       value: "https://dokarkiv.prod-fss-pub.nais.io"
     - name: REPUBLISH_FORHANDSVARSEL_WITH_ADDITIONAL_INFO_CRONJOB_ENABLED
-      value: "false"
+      value: "true"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -87,3 +87,5 @@ spec:
       value: "prod-fss.teamdokumenthandtering.dokarkiv"
     - name: DOKARKIV_URL
       value: "https://dokarkiv.prod-fss-pub.nais.io"
+    - name: REPUBLISH_FORHANDSVARSEL_WITH_ADDITIONAL_INFO_CRONJOB_ENABLED
+      value: "false"

--- a/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
@@ -55,6 +55,7 @@ data class Environment(
         aivenRegistryPassword = getEnvVar("KAFKA_SCHEMA_REGISTRY_PASSWORD"),
     ),
     val isJournalforingRetryEnabled: Boolean = getEnvVar("JOURNALFORING_RETRY_ENABLED").toBoolean(),
+    val republishForhandsvarselWithAdditionalInfoCronjobEnabled: Boolean = getEnvVar("REPUBLISH_FORHANDSVARSEL_WITH_ADDITIONAL_INFO_CRONJOB_ENABLED").toBoolean(),
 )
 
 fun getEnvVar(

--- a/src/main/kotlin/no/nav/syfo/application/IVurderingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVurderingRepository.kt
@@ -21,4 +21,6 @@ interface IVurderingRepository {
     fun getLatestVurderingForPersoner(personidenter: List<Personident>): Map<Personident, Vurdering>
 
     fun updatePersonident(nyPersonident: Personident, vurderinger: List<Vurdering>)
+
+    fun getVurdering(uuid: UUID): Vurdering?
 }

--- a/src/main/kotlin/no/nav/syfo/application/VurderingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/VurderingService.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Veilederident
 import no.nav.syfo.domain.Vurdering
 import org.slf4j.LoggerFactory
+import java.util.*
 
 class VurderingService(
     private val journalforingService: IJournalforingService,
@@ -105,6 +106,8 @@ class VurderingService(
         personidenter: List<Personident>,
     ): Map<Personident, Vurdering> =
         vurderingRepository.getLatestVurderingForPersoner(personidenter)
+
+    fun getVurdering(uuid: UUID): Vurdering? = vurderingRepository.getVurdering(uuid)
 
     companion object {
         private val log = LoggerFactory.getLogger(VurderingService::class.java)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -30,6 +30,14 @@ fun launchCronjobs(
     )
     cronjobs.add(journalforVurderingerCronjob)
 
+    if (environment.republishForhandsvarselWithAdditionalInfoCronjobEnabled) {
+        val republishForhandsvarselWithAdditionalInfoCronjob = RepublishForhandsvarselWithAdditionalInfoCronjob(
+            vurderingService = vurderingService,
+            uuids = UUIDS,
+        )
+        cronjobs.add(republishForhandsvarselWithAdditionalInfoCronjob)
+    }
+
     cronjobs.forEach {
         launchBackgroundTask(
             applicationState = applicationState,
@@ -38,3 +46,10 @@ fun launchCronjobs(
         }
     }
 }
+
+// TOOD: Add uuids to generate new forhandsvarsel for
+// Tester med to uuider fra dev, den ene har fristen gått ut, den andre ikke
+val UUIDS = listOf(
+    "5d3c80be-7156-43a9-9fec-4e891f79f18f",
+    "78ed3c4f-c702-4aaa-b836-db4d4a72f22d"
+)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -47,9 +47,13 @@ fun launchCronjobs(
     }
 }
 
-// TOOD: Add uuids to generate new forhandsvarsel for
-// Tester med to uuider fra dev, den ene har fristen gått ut, den andre ikke
 val UUIDS = listOf(
-    "5d3c80be-7156-43a9-9fec-4e891f79f18f",
-    "78ed3c4f-c702-4aaa-b836-db4d4a72f22d"
+    "b39fa390-fdd9-4750-9536-9834f709b851",
+    "d3c5afd9-dd42-4c54-adef-c0b44e24cde9",
+    "efbe9a3f-943a-4ca0-bbf2-51e8b844a29b",
+    "4ad576d4-b69f-43c4-a76d-280101b6953c",
+    "43df8eab-bd49-4f1c-ae8c-6106b21daa7a",
+    "eaaa137a-5577-4658-89d7-d266a9846479",
+    "662e3e8c-b355-4aca-99cc-9c62e71ccbe5",
+    "5465bd48-82d4-418d-b99e-0afecf9c7528"
 )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjob.kt
@@ -1,0 +1,108 @@
+package no.nav.syfo.infrastructure.cronjob
+
+import no.nav.syfo.application.VurderingService
+import no.nav.syfo.application.model.NewVurderingRequestDTO
+import no.nav.syfo.domain.DocumentComponent
+import no.nav.syfo.domain.DocumentComponentType
+import no.nav.syfo.domain.Vurdering
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.*
+
+class RepublishForhandsvarselWithAdditionalInfoCronjob(
+    private val vurderingService: VurderingService,
+    private val uuids: List<String> = emptyList(),
+) : Cronjob {
+    override val initialDelayMinutes: Long = 4
+    override val intervalDelayMinutes: Long = 10000000
+
+    private val log = LoggerFactory.getLogger(RepublishForhandsvarselWithAdditionalInfoCronjob::class.java)
+
+    override suspend fun run(): List<Result<Vurdering>> {
+        val newFrist = LocalDate.of(2025, 4, 9) // 9. april 2025
+        val result = uuids.map { uuidString ->
+            try {
+                val uuid = UUID.fromString(uuidString)
+                val vurdering = vurderingService.getVurdering(uuid)
+                if (vurdering != null) {
+                    val vurderingerForPerson = vurderingService.getVurderinger(vurdering.personident)
+                    if (vurderingerForPerson.firstOrNull()?.uuid == uuid) {
+                        val newDocument = generateNewDocument(vurdering, newFrist)
+                        val newForhandsvarselDTO = NewVurderingRequestDTO.Forhandsvarsel(
+                            personident = vurdering.personident.value,
+                            begrunnelse = vurdering.begrunnelse,
+                            document = newDocument,
+                            varselSvarfrist = newFrist,
+                        )
+                        val newVurdering = vurderingService.createNewVurdering(
+                            veilederident = vurdering.veilederident,
+                            newVurdering = newForhandsvarselDTO,
+                            callId = "cronjob-republish-forhandsvarsel",
+                        )
+                        Result.success(newVurdering)
+                    } else {
+                        Result.failure(IllegalArgumentException("Vurdering with UUID $uuid already revarslet"))
+                    }
+                } else {
+                    Result.failure(IllegalArgumentException("Vurdering with UUID $uuid not found"))
+                }
+            } catch (e: Exception) {
+                log.error("Exception caught while attempting to republish forhandsvarsel with UUID $uuidString", e)
+                Result.failure(e)
+            }
+        }
+        log.info(
+            """
+            Updated ${result.count { it.isSuccess }} forhandsvarsler in ${RepublishForhandsvarselWithAdditionalInfoCronjob::class.java.simpleName}.
+            UUIDs for new forhandsvarsler: ${result.filter { it.isSuccess }.joinToString(", ") { it.getOrNull()?.uuid.toString() }}
+            """.trimIndent()
+        )
+
+        return result
+    }
+
+    private fun generateNewDocument(vurdering: Vurdering, newFrist: LocalDate): List<DocumentComponent> {
+        return vurdering.document.map { documentComponent ->
+            if (documentComponent.type == DocumentComponentType.PARAGRAPH &&
+                documentComponent.texts.any { it.contains("For å få sykepenger er det et vilkår at du medvirker i egen sak. Dette betyr at du blant annet har en plikt til å gi opplysninger til Nav, delta i dialogmøter og ta imot tilbud om tilrettelegging.") }
+            ) {
+                val extraText = "Viktig informasjon: På grunn av en teknisk feil, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Dette brevet erstatter tidligere brev som du ikke ble varslet om, og det er kun dette brevet du skal forholde deg til. Det opprinnelige brevet kan du finne under Mine dokumenter på innloggede sider på nav.no.\n"
+                DocumentComponent(
+                    type = DocumentComponentType.PARAGRAPH,
+                    title = null,
+                    texts = listOf(
+                        extraText,
+                        "For å få sykepenger er det et vilkår at du medvirker i egen sak. Dette betyr at du blant annet har en plikt til å gi opplysninger til Nav, delta i dialogmøter og ta imot tilbud om tilrettelegging."
+                    )
+                )
+            } else if (documentComponent.type == DocumentComponentType.PARAGRAPH &&
+                documentComponent.texts.any { it.contains("Vi vurderer derfor å stanse sykepengene dine fra og med") }
+            ) {
+                DocumentComponent(
+                    type = DocumentComponentType.PARAGRAPH,
+                    title = null,
+                    texts = listOf(
+                        "Basert på opplysningene Nav har i saken har du ikke oppfylt plikten din til å medvirke, og det er heller ikke dokumentert at du hadde en rimelig grunn til å ikke medvirke. Vi vurderer derfor å stanse sykepengene dine fra og med ${newFrist.format(
+                            DateTimeFormatter.ofPattern("dd.MM.yyyy")
+                        )}."
+                    )
+                )
+            } else if (documentComponent.type == DocumentComponentType.PARAGRAPH &&
+                documentComponent.texts.any { it.contains("Vi ber om tilbakemelding fra deg innen") }
+            ) {
+                DocumentComponent(
+                    type = DocumentComponentType.PARAGRAPH,
+                    title = "Gi oss tilbakemelding",
+                    texts = listOf(
+                        "Vi ber om tilbakemelding fra deg innen ${newFrist.format(
+                            DateTimeFormatter.ofPattern("dd.MM.yyyy")
+                        )}. Etter denne datoen vil Nav vurdere å stanse sykepengene dine."
+                    )
+                )
+            } else {
+                documentComponent
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VurderingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VurderingRepository.kt
@@ -137,6 +137,18 @@ class VurderingRepository(private val database: DatabaseInterface) : IVurderingR
         connection.commit()
     }
 
+    override fun getVurdering(uuid: UUID): Vurdering? =
+        database.connection.use { connection ->
+            connection.prepareStatement(GET_VURDERING_BY_UUID).use {
+                it.setString(1, uuid.toString())
+                it.executeQuery().toList { toPVurdering() }
+            }.map {
+                it.toManglendeMedvirkningVurdering(
+                    pVarsel = connection.getVarselForVurdering(it)
+                )
+            }.firstOrNull()
+        }
+
     private fun Connection.saveVurdering(vurdering: Vurdering): PVurdering {
         val pVurdering = this.prepareStatement(INSERT_INTO_VURDERING).use {
             it.setString(1, vurdering.uuid.toString())
@@ -296,6 +308,11 @@ class VurderingRepository(private val database: DatabaseInterface) : IVurderingR
         private const val GET_VARSEL_FOR_VURDERING =
             """
                 SELECT * FROM VARSEL WHERE vurdering_id = ?
+            """
+
+        private const val GET_VURDERING_BY_UUID =
+            """
+                SELECT * FROM VURDERING WHERE uuid=?
             """
     }
 }

--- a/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
@@ -51,6 +51,7 @@ fun testEnvironment() = Environment(
     ),
     electorPath = "electorPath",
     isJournalforingRetryEnabled = true,
+    republishForhandsvarselWithAdditionalInfoCronjobEnabled = true,
 )
 
 fun testAppState() = ApplicationState(

--- a/src/test/kotlin/no/nav/syfo/generator/DocumentComponentGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/DocumentComponentGenerator.kt
@@ -2,6 +2,8 @@ package no.nav.syfo.generator
 
 import no.nav.syfo.domain.DocumentComponent
 import no.nav.syfo.domain.DocumentComponentType
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 fun generateDocumentComponent(fritekst: String, header: String = "Standard header") = listOf(
     DocumentComponent(
@@ -19,5 +21,71 @@ fun generateDocumentComponent(fritekst: String, header: String = "Standard heade
         key = "Standardtekst",
         title = null,
         texts = listOf("Dette er en standardtekst"),
+    ),
+)
+
+fun generateForhandsvarselRevarslingDocumentComponent(beskrivelse: String, svarfrist: LocalDate) = listOf(
+    DocumentComponent(
+        type = DocumentComponentType.HEADER_H1,
+        title = null,
+        texts = listOf("Varsel om mulig stans av sykepenger"),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf("For å få sykepenger er det et vilkår at du medvirker i egen sak. Dette betyr at du blant annet har en plikt til å gi opplysninger til Nav, delta i dialogmøter og ta imot tilbud om tilrettelegging."),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf(
+            "Basert på opplysningene Nav har i saken har du ikke oppfylt plikten din til å medvirke, og det er heller ikke dokumentert at du hadde en rimelig grunn til å ikke medvirke. Vi vurderer derfor å stanse sykepengene dine fra og med ${svarfrist.format(
+                DateTimeFormatter.ofPattern("dd.MM.yyyy")
+            )}."
+        ),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf("Vi har ikke tatt en endelig avgjørelse om å stanse dine sykepenger."),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf(beskrivelse),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = "Gi oss tilbakemelding",
+        texts = listOf(
+            "Vi ber om tilbakemelding fra deg innen ${svarfrist.format(
+                DateTimeFormatter.ofPattern("dd.MM.yyyy")
+            )}. Etter denne datoen vil Nav vurdere å stanse sykepengene dine."
+        ),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = "Kontaktinformasjon",
+        texts = listOf("Kontakt oss gjerne på nav.no/skriv-til-oss eller telefon 55 55 33 33."),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = "Lovhjemmel",
+        texts = listOf("Krav til medvirkning i egen sak er beskrevet i folketrygdloven § 8-8 første og tredje ledd."),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf("«Medlemmet har plikt til å gi opplysninger til arbeidsgiveren og Arbeids- og velferdsetaten om egen funksjonsevne og bidra til at hensiktsmessige tiltak for å tilrettelegge arbeidet og utprøving av funksjonsevnen blir utredet og iverksatt, se også § 21-3. Medlemmet plikter også å medvirke ved utarbeiding og gjennomføring av oppfølgingsplaner og delta i dialogmøter som nevnt i arbeidsmiljøloven § 4-6 og folketrygdloven § 8-7 a. (…)"),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf("Retten til sykepenger faller bort dersom medlemmet uten rimelig grunn nekter å gi opplysninger eller medvirke til utredning, eller uten rimelig grunn nekter å ta imot tilbud om behandling, rehabilitering, tilrettelegging av arbeid og arbeidsutprøving eller arbeidsrettede tiltak, se også § 21-8. Det samme gjelder dersom medlemmet uten rimelig grunn unnlater å medvirke ved utarbeiding og gjennomføring av oppfølgingsplaner, unnlater å delta i dialogmøter som nevnt i første ledd, eller unnlater å være i arbeidsrelatert aktivitet som nevnt i andre ledd.»"),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf("Med vennlig hilsen", "VEILEDER_NAVN", "Nav"),
     ),
 )

--- a/src/test/kotlin/no/nav/syfo/generator/VurderingGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/VurderingGenerator.kt
@@ -12,6 +12,7 @@ fun generateVurdering(
     document: List<DocumentComponent> = generateDocumentComponent(begrunnelse),
     type: VurderingType,
     createdAt: OffsetDateTime = OffsetDateTime.now(),
+    svarfrist: LocalDate = LocalDate.now().plusWeeks(3),
 ) = when (type) {
     VurderingType.FORHANDSVARSEL -> Vurdering.Forhandsvarsel(
         uuid = UUID.randomUUID(),
@@ -24,7 +25,7 @@ fun generateVurdering(
         varsel = Varsel(
             uuid = UUID.randomUUID(),
             createdAt = OffsetDateTime.now(),
-            svarfrist = LocalDate.now().plusWeeks(3),
+            svarfrist = svarfrist,
         ),
     )
     VurderingType.OPPFYLT -> Vurdering.Oppfylt(

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjobSpek.kt
@@ -1,0 +1,161 @@
+package no.nav.syfo.infrastructure.cronjob
+
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.ExternalMockEnvironment
+import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT
+import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_NAME_WITH_DASH
+import no.nav.syfo.UserConstants.PDF_FORHANDSVARSEL
+import no.nav.syfo.application.VurderingService
+import no.nav.syfo.domain.Vurdering
+import no.nav.syfo.domain.VurderingType
+import no.nav.syfo.generator.generateForhandsvarselRevarslingDocumentComponent
+import no.nav.syfo.generator.generateVurdering
+import no.nav.syfo.infrastructure.clients.pdfgen.VurderingPdfService
+import no.nav.syfo.infrastructure.database.dropData
+import no.nav.syfo.infrastructure.database.repository.VurderingRepository
+import no.nav.syfo.infrastructure.journalforing.JournalforingService
+import no.nav.syfo.infrastructure.kafka.VurderingProducer
+import no.nav.syfo.infrastructure.kafka.VurderingRecord
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeTrue
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.Future
+
+class RepublishForhandsvarselWithAdditionalInfoCronjobSpek : Spek({
+    describe(RepublishForhandsvarselWithAdditionalInfoCronjob::class.java.simpleName) {
+        val externalMockEnvironment = ExternalMockEnvironment.instance
+        val database = externalMockEnvironment.database
+
+        val vurderingRepository = VurderingRepository(database = database)
+        val vurderingPdfService = VurderingPdfService(
+            externalMockEnvironment.pdfgenClient,
+            externalMockEnvironment.pdlClient,
+        )
+        val journalforingService = JournalforingService(
+            dokarkivClient = externalMockEnvironment.dokarkivClient,
+            pdlClient = externalMockEnvironment.pdlClient,
+            isJournalforingRetryEnabled = externalMockEnvironment.environment.isJournalforingRetryEnabled,
+        )
+
+        val mockVurderingProducer = mockk<KafkaProducer<String, VurderingRecord>>(relaxed = true)
+        val vurderingProducer = VurderingProducer(
+            producer = mockVurderingProducer,
+        )
+
+        val vurderingService = VurderingService(
+            vurderingRepository = vurderingRepository,
+            vurderingPdfService = vurderingPdfService,
+            journalforingService = journalforingService,
+            vurderingProducer = vurderingProducer,
+        )
+
+        beforeEachTest {
+            clearAllMocks()
+            coEvery { mockVurderingProducer.send(any()) } returns mockk<Future<RecordMetadata>>(relaxed = true)
+        }
+
+        afterEachTest {
+            database.dropData()
+        }
+
+        describe("RepublishForhandsvarselWithAdditionalInfoCronjob") {
+            val begrunnelse1 = "En begrunnelse1"
+            val svarfrist1 = LocalDate.of(2025, 3, 1)
+            val vurderingForhandsvarsel1 = generateVurdering(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                begrunnelse = begrunnelse1,
+                document = generateForhandsvarselRevarslingDocumentComponent(
+                    beskrivelse = begrunnelse1,
+                    svarfrist = svarfrist1,
+                ),
+                type = VurderingType.FORHANDSVARSEL,
+                svarfrist = svarfrist1,
+            )
+            val begrunnelse2 = "En begrunnelse2"
+            val svarfrist2 = LocalDate.of(2025, 3, 7)
+            val vurderingForhandsvarsel2 = generateVurdering(
+                personident = ARBEIDSTAKER_PERSONIDENT_NAME_WITH_DASH,
+                begrunnelse = begrunnelse2,
+                document = generateForhandsvarselRevarslingDocumentComponent(
+                    beskrivelse = begrunnelse2,
+                    svarfrist = svarfrist2,
+                ),
+                type = VurderingType.FORHANDSVARSEL,
+                svarfrist = svarfrist2,
+            )
+
+            it("Henter gamle, overskriver teksten og svarfrist") {
+                val uuids = listOf(
+                    vurderingForhandsvarsel1.uuid.toString(),
+                    vurderingForhandsvarsel2.uuid.toString(),
+                )
+                val republishForhandsvarselWithAdditionalInfoCronjob = RepublishForhandsvarselWithAdditionalInfoCronjob(
+                    vurderingService = vurderingService,
+                    uuids = uuids,
+                )
+                vurderingRepository.saveManglendeMedvirkningVurdering(
+                    vurdering = vurderingForhandsvarsel1,
+                    vurderingPdf = PDF_FORHANDSVARSEL,
+                )
+                vurderingRepository.saveManglendeMedvirkningVurdering(
+                    vurdering = vurderingForhandsvarsel2,
+                    vurderingPdf = PDF_FORHANDSVARSEL,
+                )
+
+                runBlocking {
+                    val result = republishForhandsvarselWithAdditionalInfoCronjob.run()
+                    result.size shouldBeEqualTo 2
+                    result.forEach { it.isSuccess shouldBeEqualTo true }
+
+                    result[0].getOrThrow().begrunnelse shouldBeEqualTo begrunnelse1
+                    result[1].getOrThrow().begrunnelse shouldBeEqualTo begrunnelse2
+
+                    val vurderinger1 = vurderingRepository.getVurderinger(personident = vurderingForhandsvarsel1.personident)
+                    vurderinger1.size shouldBeEqualTo 2 // Har både nytt og gammelt varsel i databasen
+                    vurderinger1.all { it.vurderingType == VurderingType.FORHANDSVARSEL }.shouldBeTrue()
+                    val newForhandsvarsel1 = vurderinger1.first() as Vurdering.Forhandsvarsel
+                    newForhandsvarsel1.createdAt shouldBeGreaterThan vurderinger1.last().createdAt // Sortert DESC på created_at, så første er den nyeste
+                    newForhandsvarsel1.varsel.svarfrist shouldBeEqualTo LocalDate.of(2025, 4, 9)
+                    newForhandsvarsel1.document.filter { documentComponent ->
+                        documentComponent.texts.contains(
+                            "Viktig informasjon: På grunn av en teknisk feil, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Dette brevet erstatter tidligere brev som du ikke ble varslet om, og det er kun dette brevet du skal forholde deg til. Det opprinnelige brevet kan du finne under Mine dokumenter på innloggede sider på nav.no.\n"
+                        )
+                    }.size shouldBeEqualTo 1
+                    newForhandsvarsel1.document.filter { documentComponent ->
+                        documentComponent.texts.contains(
+                            svarfrist1.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+                        )
+                    }.size shouldBeEqualTo 0 // Inneholder ingen spor av gammel svarfrist
+                    newForhandsvarsel1.journalpostId shouldBeEqualTo null
+
+                    val vurderinger2 = vurderingRepository.getVurderinger(personident = vurderingForhandsvarsel2.personident)
+                    vurderinger2.size shouldBeEqualTo 2 // Har både nytt og gammelt varsel i databasen
+                    vurderinger2.all { it.vurderingType == VurderingType.FORHANDSVARSEL }.shouldBeTrue()
+                    val newForhandsvarsel2 = vurderinger1.first() as Vurdering.Forhandsvarsel
+                    newForhandsvarsel2.createdAt shouldBeGreaterThan vurderinger2.last().createdAt // Sortert DESC på created_at, så første er den nyeste
+                    newForhandsvarsel2.varsel.svarfrist shouldBeEqualTo LocalDate.of(2025, 4, 9)
+                    newForhandsvarsel2.document.filter { documentComponent ->
+                        documentComponent.texts.contains(
+                            "Viktig informasjon: På grunn av en teknisk feil, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Dette brevet erstatter tidligere brev som du ikke ble varslet om, og det er kun dette brevet du skal forholde deg til. Det opprinnelige brevet kan du finne under Mine dokumenter på innloggede sider på nav.no.\n"
+                        )
+                    }.size shouldBeEqualTo 1
+                    newForhandsvarsel2.document.filter { documentComponent ->
+                        documentComponent.texts.contains(
+                            svarfrist1.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+                        )
+                    }.size shouldBeEqualTo 0 // Inneholder ingen spor av gammel svarfrist
+                    newForhandsvarsel2.journalpostId shouldBeEqualTo null
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Hva gjør den:
- Gitt uuider (som vi må finne på forhånd og legge inn i lista)
- Finn nåværende vurderinger
- Kopier over all info, bortsett fra `svarfrist` og `document`
- Skriv over `document` med nye datoer (2 steder)
- Legger på en ekstratekst under overskriften og før første setning: `Viktig informasjon! ...`

Hva gjenstår:

- [x] Dobbeltsjekke ekstra-tekst med Stine og co
- [x] Teste i dev for noen uuider i databasen
- [x] Sjekke gosys at dokumentet som journalføres har riktige datoer
- [ ] Toggle på i prod

<img width="865" alt="image" src="https://github.com/user-attachments/assets/790dbbe9-df79-4571-907a-1323dffd1e14" />
